### PR TITLE
Parse (and test parsing of) Scala case classes

### DIFF
--- a/panrec.cabal
+++ b/panrec.cabal
@@ -17,10 +17,14 @@ library
   hs-source-dirs:      src
   ghc-options:         -Wall
   exposed-modules:     Lib
+                     , Data.Parsers
                      , Data.Scala
                      , Data.Record
   build-depends:       base >= 4.7 && < 5
+                     , attoparsec
+                     , bytestring
   default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
 
 executable panrec-exe
   hs-source-dirs:      app
@@ -38,10 +42,14 @@ test-suite panrec-test
                      , panrec
                      , hspec >= 2.7.1 && < 2.8.0
                      , QuickCheck >= 2.13.1 && < 2.14
+                     , bytestring
+                     , raw-strings-qq
   other-modules:       Types
 
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
+  default-extensions:  QuasiQuotes
+                     , OverloadedStrings
 
 source-repository head
   type:     git

--- a/src/Data/Parsers.hs
+++ b/src/Data/Parsers.hs
@@ -1,0 +1,10 @@
+module Data.Parsers where
+
+import           Control.Applicative              ((<|>))
+import           Data.Attoparsec.ByteString.Char8
+
+letterOrDigit :: Parser Char
+letterOrDigit = letter_ascii <|> digit
+
+endOfLineOrSpace :: Parser Char
+endOfLineOrSpace = (pure ' ' <$> endOfLine) <|> space

--- a/src/Data/Record.hs
+++ b/src/Data/Record.hs
@@ -29,6 +29,8 @@ class Record a where
   typing :: a -> Bool
   -- | Records must provide a way to access their fields
   fields :: a -> [String]
+  -- | Record smust provide a way to access their names
+  name :: a -> String
   -- | Build this type from another record
   fromRecord :: Record b => b -> a
 

--- a/src/Data/Scala.hs
+++ b/src/Data/Scala.hs
@@ -1,8 +1,19 @@
-module Data.Scala where
+module Data.Scala (
+  CaseClass(..)
+  , caseClassParser
+  , fieldParser
+  , parseField
+  , parseFields
+  , parseRecord) where
 
-import           Data.Record (Casing (..), Record (..))
+import           Control.Applicative              ((<|>))
+import           Data.Attoparsec.ByteString.Char8
+import           Data.ByteString                  (ByteString)
+import           Data.Parsers
+import           Data.Record                      (Casing (..), Record (..))
 
-data CaseClass = CaseClass { _fields :: [String] } deriving (Eq, Show)
+data CaseClass = CaseClass { _fields :: [String]
+                           , _name   :: String } deriving (Eq, Show)
 
 instance Record CaseClass where
   recordCasing = pure UpperCamel
@@ -10,4 +21,40 @@ instance Record CaseClass where
   constructor _ = ("case class(" ++) . (++ ")")
   typing = pure True
   fields = _fields
-  fromRecord b = CaseClass $ fields b
+  name = _name
+  fromRecord b = CaseClass (fields b) (name b)
+
+
+fieldParser :: Parser (String, String)
+fieldParser = do
+  _ <- skipWhile isSpace
+  fieldName <- many' letterOrDigit
+               <* try (many' space)
+               <* char ':'
+               <* try (many' space)
+  fieldType <- many' letterOrDigit
+               <* (try
+                   (char ',' <|> endOfLineOrSpace)
+                   <|> char ')')
+  return (fieldName, fieldType)
+
+
+caseClassParser :: Parser CaseClass
+caseClassParser = do
+  skipMany space
+  _ <- string "case class" <* many' endOfLineOrSpace
+  recordName <- many' letterOrDigit
+  _ <- char '('
+  skipMany endOfLineOrSpace
+  recordFields <- many' (fieldParser)
+  skipMany endOfLineOrSpace
+  return $ CaseClass (fst <$> recordFields) recordName
+
+parseField :: ByteString -> Either String (String, String)
+parseField = parseOnly fieldParser
+
+parseFields :: ByteString -> Either String [(String, String)]
+parseFields = parseOnly (many' fieldParser)
+
+parseRecord :: ByteString -> Either String CaseClass
+parseRecord = parseOnly caseClassParser

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,13 +1,57 @@
+import qualified Data.Scala as Scala
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Char8 (pack)
 import           Data.Record
 import           Test.Hspec
 import           Test.QuickCheck
+import           Text.RawString.QQ
 import           Types
 
 main :: IO ()
 main = hspec $ do
-  describe "identity conversions" $
-    it "should not change the input value" $
+  describe "identity conversions" $ do
+    it "should not change the input value" $ do
       property $ quickCheck unchangedScala
+  describe "Scala parsers" $ do
+    it "should parse fields terminated with returns" $ do
+      Scala.parseField exampleFieldReturn `shouldBe` (Right $ ("x", "Int"))
+    it "should parse fields terminated with spaces" $ do
+      Scala.parseField exampleFieldSpace `shouldBe` (Right $ ("x", "Int"))
+    it "should parse fields not terminated by commas" $ do
+      Scala.parseField exampleFieldLast `shouldBe` (Right $ ("x", "Int"))
+    it "should parse a collection of fields" $ do
+      Scala.parseFields justFields `shouldBe` (Right $ [ ("x", "Int")
+                                                       , ("y", "Int")
+                                                       , ("z", "Int")])
+    it "should read a scala case class correctly with spaces" $ do
+      Scala.parseRecord exampleCaseClassSpaces `shouldBe` (Right $ Scala.CaseClass ["x", "y"] "Foo")
+    it "should read a scala case class correctly with returns" $ do
+      Scala.parseRecord exampleCaseClassReturns `shouldBe` (Right $ Scala.CaseClass ["x", "y"] "Foo")
+
 
 unchangedScala :: TestCaseClass -> Bool
 unchangedScala (TestCaseClass x) = (fromRecord x) == x
+
+exampleCaseClassReturns :: ByteString
+exampleCaseClassReturns = pack [r|case class Foo(
+  x: Int,
+  y: String
+)|]
+
+exampleCaseClassSpaces :: ByteString
+exampleCaseClassSpaces = "case class Foo(x: Int, y: Int)"
+
+exampleFieldReturn :: ByteString
+exampleFieldReturn = "x: Int,\n"
+
+exampleFieldSpace :: ByteString
+exampleFieldSpace = "x: Int, "
+
+exampleFieldLast :: ByteString
+exampleFieldLast = "x: Int)"
+
+justFields :: ByteString
+justFields = pack [r|x: Int,
+y: Int,
+z: Int,
+a: Int|]

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -8,4 +8,5 @@ newtype TestCaseClass = TestCaseClass CaseClass deriving (Show)
 instance Arbitrary TestCaseClass where
   arbitrary = do
     fs <- arbitrary
-    return . TestCaseClass $ CaseClass fs
+    nm <- arbitrary
+    return . TestCaseClass $ CaseClass fs nm


### PR DESCRIPTION
Overview
-----

This PR adds some parsing and tests of parsing for Scala case classes. It extracts the case class
name field name, and field types, though it doesn't yet do anything with the types. It'll need to once I
get to the translation layer.

Testing
-----

run tests